### PR TITLE
update upstream 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update to upstream version `0.8.0`.
+
 ## [0.2.1] - 2025-02-25
 
 ### Fixed

--- a/helm/cloud-provider-proxmox/Chart.yaml
+++ b/helm/cloud-provider-proxmox/Chart.yaml
@@ -23,4 +23,4 @@ version: 0.2.13
 # It is recommended to use it with quotes.
 appVersion: v0.8.0
 annotations:
-   application.giantswarm.io/team: "rocket"
+  application.giantswarm.io/team: "rocket"

--- a/helm/cloud-provider-proxmox/Chart.yaml
+++ b/helm/cloud-provider-proxmox/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: proxmox-cloud-controller-manager
 description: Cloud Controller Manager plugin for Proxmox
 type: application
-home: https://github.com/sergelogvinov/proxmox-cloud-controller-manager
+home: https://github.com/giantswarm/cloud-provider-proxmox-app
 icon: https://raw.githubusercontent.com/sergelogvinov/proxmox-cloud-controller-manager/main/charts/proxmox-cloud-controller-manager/icon.png
 sources:
   - https://github.com/sergelogvinov/proxmox-cloud-controller-manager
@@ -11,16 +11,16 @@ keywords:
   - proxmox
   - kubernetes
 maintainers:
-  - name: sergelogvinov
-    url: https://github.com/sergelogvinov
+  - name: Team Rocket
+    email: team-rocket@giantswarm.io
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.13
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v0.7.0
+appVersion: v0.8.0
 annotations:
-  application.giantswarm.io/team: "rocket"
+   application.giantswarm.io/team: "rocket"

--- a/helm/cloud-provider-proxmox/README.md
+++ b/helm/cloud-provider-proxmox/README.md
@@ -1,6 +1,6 @@
 # proxmox-cloud-controller-manager
 
-![Version: 0.2.11](https://img.shields.io/badge/Version-0.2.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.7.0](https://img.shields.io/badge/AppVersion-v0.7.0-informational?style=flat-square)
+![Version: 0.2.13](https://img.shields.io/badge/Version-0.2.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.0](https://img.shields.io/badge/AppVersion-v0.8.0-informational?style=flat-square)
 
 Cloud Controller Manager plugin for Proxmox
 
@@ -86,6 +86,7 @@ helm upgrade -i --namespace=kube-system -f proxmox-ccm.yaml \
 | imagePullSecrets | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | fullnameOverride | string | `""` |  |
+| extraEnvs | list | `[]` | Any extra environments for talos-cloud-controller-manager |
 | extraArgs | list | `[]` | Any extra arguments for talos-cloud-controller-manager |
 | enabledControllers | list | `["cloud-node","cloud-node-lifecycle"]` | List of controllers should be enabled. Use '*' to enable all controllers. Support only `cloud-node,cloud-node-lifecycle` controllers. |
 | logVerbosityLevel | int | `2` | Log verbosity level. See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md for description of individual verbosity levels. |

--- a/helm/cloud-provider-proxmox/ci/values.yaml
+++ b/helm/cloud-provider-proxmox/ci/values.yaml
@@ -7,11 +7,15 @@ affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
-      - matchExpressions:
-        - key: node-role.kubernetes.io/control-plane
-          operator: Exists
+        - matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
 
 logVerbosityLevel: 4
+
+extraEnvs:
+  - name: KUBERNETES_SERVICE_HOST
+    value: 127.0.0.1
 
 enabledControllers:
   - cloud-node

--- a/helm/cloud-provider-proxmox/templates/deployment.yaml
+++ b/helm/cloud-provider-proxmox/templates/deployment.yaml
@@ -71,6 +71,10 @@ spec:
           {{- with .Values.extraArgs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.extraEnvs }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: metrics
               containerPort: 10258

--- a/helm/cloud-provider-proxmox/values.yaml
+++ b/helm/cloud-provider-proxmox/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   # -- Proxmox CCM image.
-  repository: ghcr.io/sergelogvinov/proxmox-cloud-controller-manager
+  repository: gsoci.azurecr.io/giantswarm/proxmox-cloud-controller-manager
   # -- Always or IfNotPresent
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
@@ -49,7 +49,7 @@ existingConfigSecretKey: config.yaml
 config:
   features:
     # specify provider: proxmox if you are using capmox (cluster api provider for proxmox)
-    provider: "default"
+    provider: proxmox
   clusters: []
   #   - url: https://cluster-api-1.exmple.com:8006/api2/json
   #     insecure: false
@@ -123,6 +123,7 @@ securityContext:
   capabilities:
     drop:
       - ALL
+  readOnlyRootFilesystem: true
   seccompProfile:
     type: RuntimeDefault
 
@@ -133,9 +134,9 @@ resources:
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi
   requests:
     cpu: 10m
     memory: 32Mi

--- a/helm/cloud-provider-proxmox/values.yaml
+++ b/helm/cloud-provider-proxmox/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   # -- Proxmox CCM image.
-  repository: gsoci.azurecr.io/giantswarm/proxmox-cloud-controller-manager
+  repository: ghcr.io/sergelogvinov/proxmox-cloud-controller-manager
   # -- Always or IfNotPresent
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
@@ -16,8 +16,15 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# -- Any extra environments for talos-cloud-controller-manager
+extraEnvs:
+  []
+  # - name: KUBERNETES_SERVICE_HOST
+  #   value: 127.0.0.1
+
 # -- Any extra arguments for talos-cloud-controller-manager
-extraArgs: []
+extraArgs:
+  []
   # - --cluster-name=kubernetes
 
 # -- List of controllers should be enabled.
@@ -42,7 +49,7 @@ existingConfigSecretKey: config.yaml
 config:
   features:
     # specify provider: proxmox if you are using capmox (cluster api provider for proxmox)
-    provider: proxmox
+    provider: "default"
   clusters: []
   #   - url: https://cluster-api-1.exmple.com:8006/api2/json
   #     insecure: false
@@ -66,7 +73,8 @@ priorityClassName: system-cluster-critical
 
 # -- Add additional init containers to the CCM pods.
 # ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
-initContainers: []
+initContainers:
+  []
   # - name: loadbalancer
   #   restartPolicy: Always
   #   image: ghcr.io/sergelogvinov/haproxy:2.8.3-alpine3.18
@@ -89,7 +97,8 @@ initContainers: []
 
 # -- hostAliases Deployment pod host aliases
 # ref: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
-hostAliases: []
+hostAliases:
+  []
   # - ip: 127.0.0.1
   #   hostnames:
   #     - proxmox.domain.com
@@ -113,8 +122,7 @@ securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
-    - ALL
-  readOnlyRootFilesystem: true
+      - ALL
   seccompProfile:
     type: RuntimeDefault
 
@@ -125,9 +133,9 @@ resources:
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  limits:
-    cpu: 100m
-    memory: 128Mi
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
   requests:
     cpu: 10m
     memory: 32Mi
@@ -146,7 +154,8 @@ updateStrategy:
 
 # -- Node labels for data pods assignment.
 # ref: https://kubernetes.io/docs/user-guide/node-selection/
-nodeSelector: {}
+nodeSelector:
+  {}
   # node-role.kubernetes.io/control-plane: ""
 
 # -- Tolerations for data pods assignment.

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,4 +3,7 @@
     // Base config - https://github.com/giantswarm/renovate-presets/blob/main/default.json5
     "github>giantswarm/renovate-presets:default.json5",
   ],
+  "vendir": {
+    "enabled": false
+  }
 }

--- a/sync/patches/chart/_chart.yaml.patch
+++ b/sync/patches/chart/_chart.yaml.patch
@@ -1,11 +1,30 @@
 diff --git a/helm/cloud-provider-proxmox/Chart.yaml b/helm/cloud-provider-proxmox/Chart.yaml
-index f225374..cf9dd5b 100644
+index 475be2d..eda48ee 100644
 --- a/helm/cloud-provider-proxmox/Chart.yaml
 +++ b/helm/cloud-provider-proxmox/Chart.yaml
-@@ -22,3 +22,6 @@ version: 0.2.11
+@@ -2,7 +2,7 @@ apiVersion: v2
+ name: proxmox-cloud-controller-manager
+ description: Cloud Controller Manager plugin for Proxmox
+ type: application
+-home: https://github.com/sergelogvinov/proxmox-cloud-controller-manager
++home: https://github.com/giantswarm/cloud-provider-proxmox-app
+ icon: https://raw.githubusercontent.com/sergelogvinov/proxmox-cloud-controller-manager/main/charts/proxmox-cloud-controller-manager/icon.png
+ sources:
+   - https://github.com/sergelogvinov/proxmox-cloud-controller-manager
+@@ -11,8 +11,8 @@ keywords:
+   - proxmox
+   - kubernetes
+ maintainers:
+-  - name: sergelogvinov
+-    url: https://github.com/sergelogvinov
++  - name: Team Rocket
++    email: team-rocket@giantswarm.io
+ # This is the chart version. This version number should be incremented each time you make changes
+ # to the chart and its templates, including the app version.
+ # Versions are expected to follow Semantic Versioning (https://semver.org/)
+@@ -22,3 +22,5 @@ version: 0.2.13
  # follow Semantic Versioning. They should reflect the version the application is using.
  # It is recommended to use it with quotes.
- appVersion: v0.7.0
-+
+ appVersion: v0.8.0
 +annotations:
-+  application.giantswarm.io/team: "rocket"
++   application.giantswarm.io/team: "rocket"

--- a/sync/patches/chart/_chart.yaml.patch
+++ b/sync/patches/chart/_chart.yaml.patch
@@ -27,4 +27,4 @@ index 475be2d..eda48ee 100644
  # It is recommended to use it with quotes.
  appVersion: v0.8.0
 +annotations:
-+   application.giantswarm.io/team: "rocket"
++  application.giantswarm.io/team: "rocket"

--- a/sync/patches/values/_values.yaml.patch
+++ b/sync/patches/values/_values.yaml.patch
@@ -1,5 +1,5 @@
 diff --git a/helm/cloud-provider-proxmox/values.yaml b/helm/cloud-provider-proxmox/values.yaml
-index af03799..6d1ef12 100644
+index ad01c2f..c94e1b3 100644
 --- a/helm/cloud-provider-proxmox/values.yaml
 +++ b/helm/cloud-provider-proxmox/values.yaml
 @@ -6,7 +6,7 @@ replicaCount: 1
@@ -11,24 +11,24 @@ index af03799..6d1ef12 100644
    # -- Always or IfNotPresent
    pullPolicy: IfNotPresent
    # -- Overrides the image tag whose default is the chart appVersion.
-@@ -42,7 +42,7 @@ existingConfigSecretKey: config.yaml
+@@ -49,7 +49,7 @@ existingConfigSecretKey: config.yaml
  config:
    features:
      # specify provider: proxmox if you are using capmox (cluster api provider for proxmox)
--    provider: 'default'
+-    provider: "default"
 +    provider: proxmox
    clusters: []
    #   - url: https://cluster-api-1.exmple.com:8006/api2/json
    #     insecure: false
-@@ -114,6 +114,7 @@ securityContext:
+@@ -123,6 +123,7 @@ securityContext:
    capabilities:
      drop:
-     - ALL
+       - ALL
 +  readOnlyRootFilesystem: true
    seccompProfile:
      type: RuntimeDefault
  
-@@ -124,9 +125,9 @@ resources:
+@@ -133,9 +134,9 @@ resources:
    # choice for the user. This also increases chances charts run on environments with little
    # resources, such as Minikube. If you do want to specify resources, uncomment the following
    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,10 +2,10 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: 'chore: release v0.7.0...'
-      sha: bb868bcbd7827e54d008b39289255f2931b75776
+      commitTitle: 'chore: release v0.8.0...'
+      sha: 2e35df2db0e9a9bb1fb516104b0c90196a6dc9d9
       tags:
-      - v0.7.0
+      - v0.8.0
     path: proxmox-cloud-controller-manager
   path: vendor
 - contents:

--- a/vendir.yml
+++ b/vendir.yml
@@ -7,7 +7,7 @@ directories:
         git:
           depth: 1
           url: https://github.com/sergelogvinov/proxmox-cloud-controller-manager
-          ref: "v0.7.0"
+          ref: "v0.8.0"
         includePaths:
           - charts/proxmox-cloud-controller-manager/**/*
   - path: helm/cloud-provider-proxmox


### PR DESCRIPTION
This PR:

- updates the chart to 0.8.0

Note: this PR supersedes [this renovate PR](https://github.com/giantswarm/cloud-provider-proxmox-app/pull/14). This is because Renovate's vendir manager cannot apply our custom patches.

This PR also disables the vendir manager.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
