### PR TITLE
chore: update Proxmox app icon to v2 (light.svg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update Proxmox app icon to `https://s.giantswarm.io/app-icons/proxmox/2/light.svg`.
+
 ## [0.4.1] - 2026-03-17
 
 ### Fixed

--- a/helm/cloud-provider-proxmox/Chart.yaml
+++ b/helm/cloud-provider-proxmox/Chart.yaml
@@ -3,7 +3,7 @@ name: proxmox-cloud-controller-manager
 description: Cloud Controller Manager plugin for Proxmox
 type: application
 home: https://github.com/giantswarm/cloud-provider-proxmox-app
-icon: https://s.giantswarm.io/app-icons/proxmox/1/dark.png
+icon: https://s.giantswarm.io/app-icons/proxmox/2/light.svg
 sources:
   - https://github.com/sergelogvinov/proxmox-cloud-controller-manager
 keywords:

--- a/sync/patches/chart/_chart.yaml.patch
+++ b/sync/patches/chart/_chart.yaml.patch
@@ -9,7 +9,7 @@ index 475be2d..eda48ee 100644
 -home: https://github.com/sergelogvinov/proxmox-cloud-controller-manager
 -icon: https://raw.githubusercontent.com/sergelogvinov/proxmox-cloud-controller-manager/main/charts/proxmox-cloud-controller-manager/icon.png
 +home: https://github.com/giantswarm/cloud-provider-proxmox-app
-+icon: https://s.giantswarm.io/app-icons/proxmox/1/dark.png
++icon: https://s.giantswarm.io/app-icons/proxmox/2/light.svg
  sources:
    - https://github.com/sergelogvinov/proxmox-cloud-controller-manager
  keywords:


### PR DESCRIPTION
Updates the Proxmox app icon to the new shared web-asset:

`https://s.giantswarm.io/app-icons/proxmox/2/light.svg`

The sync-patch source is updated as well, so the change survives the next upstream chart sync.

> [!IMPORTANT]
> The new icon file only becomes available once [`web-assets`](https://github.com/giantswarm/web-assets) `v0.32.0` is released and rolled out. Please do not merge before then.

Context: giantswarm/giantswarm#36874
